### PR TITLE
Solved the "option selected value" bug

### DIFF
--- a/ezpadova/parsec.py
+++ b/ezpadova/parsec.py
@@ -87,7 +87,6 @@ def get_photometry_list():
 
     data = urlopen(webserver + '/cgi-bin/cmd').read().decode('utf8')
     data = data.replace("option selected value", "option value")
-    # this is to solve the "option selected value" bug
     p = Parser()
     p.feed(data)
     phot_list = p.data['photsys_file'][1:]   # first one is a list

--- a/ezpadova/parsec.py
+++ b/ezpadova/parsec.py
@@ -86,6 +86,8 @@ def get_photometry_list():
                 self.current.append(data.replace('\n', ' '))
 
     data = urlopen(webserver + '/cgi-bin/cmd').read().decode('utf8')
+    data = data.replace("option selected value", "option value")
+    # this is to solve the "option selected value" bug
     p = Parser()
     p.feed(data)
     phot_list = p.data['photsys_file'][1:]   # first one is a list

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-rm -rf ./build
-python setup.py build_ext --inplace
-python setup.py install

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+rm -rf ./build
+python setup.py build_ext --inplace
+python setup.py install


### PR DESCRIPTION
Here goes the error message of the bug...

```python
In [1]: import ezpadova
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-1-c0afcec20e86> in <module>()
----> 1 import ezpadova

~/anaconda3/lib/python3.6/site-packages/ezpadova-1.0-py3.6.egg/ezpadova/__init__.py in <module>()
      1 from .cmd import get_Z_isochrones, get_one_isochrone, get_t_isochrones
----> 2 from . import parsec

~/anaconda3/lib/python3.6/site-packages/ezpadova-1.0-py3.6.egg/ezpadova/parsec.py in <module>()
    481         return r
    482
--> 483 get_photometry_list()

~/anaconda3/lib/python3.6/site-packages/ezpadova-1.0-py3.6.egg/ezpadova/parsec.py in get_photometry_list()
     94     for key, val in phot_list:
     95         if len(val) > 0:
---> 96             key = key.replace('tab_mag_odfnew/tab_mag_', '').replace('.dat', '')
     97         final.append((key, val))
     98

AttributeError: 'NoneType' object has no attribute 'replace'

```

The reason is that some start tags start with "option selected value" rather than "option value"...
I simply replace the sub-string so they are consistent now.
