### PR TITLE
Fix Defaults

### DIFF
--- a/ezpadova/parsec.json
+++ b/ezpadova/parsec.json
@@ -88,39 +88,36 @@
 	},
 	"map_carbon_stars" : {
 		"loidl": ["loidl01", "Loidl et al. (2001) (as in Marigo et al. (2008) and Girardi et al. (2008))"],
-		"aringer": ["aringer09", "Aringer et al. (2009) (Note: The interpolation scheme has been slightly improved w.r.t. to the paper's Fig. 19."] 
+		"aringer": ["aringer09", "Aringer et al. (2009) (Note: The interpolation scheme has been slightly improved w.r.t. to the paper's Fig. 19."]
 	},
 	"map_circum_Mstars": {
-		"nodustM": ["no dust", ""],
-		"sil": ["Silicates", "Bressan et al. (1998)"],
-		"AlOx": ["100% AlOx", "Groenewegen (2006)"],
-		"dpmod60alox40": ["60% Silicate + 40% AlOx", "Groenewegen (2006)"],
-		"dpmod": ["100% Silicate", "Groenewegen (2006)"]
+		"nodustM": ["nodustM", "no dust"],
+		"sil": ["sil", "Silicates as in Bressan et al. (1998)"],
+		"AlOx": ["AlOx", "100% AlOx as in Groenewegen (2006)"],
+		"dpmod60alox40": ["dpmod60alox40", "60% Silicate + 40% AlOx as in Groenewegen (2006)"],
+		"dpmod": ["dpmod", "100% Silicate as in Groenewegen (2006)"],
+		"Rouleau13_jan17": ["Rouleau13_jan17", "M+C Model: Rouleau & Martin (1991) logεS=-13 (see Nanni et al. (2016))"],
+		"Jaeger400_12_jan17": ["Jaeger400_12_jan17", "M+C Model: Jaeger et al. (1998) 400K, logεS=-12 (see Nanni et al. (2016))"],
+		"Rouleau12_mar17": ["Rouleau12_mar17", "M+C Model: Rouleau & Martin (1991) logεS=-12 (see Nanni et al. (2016))"]
 	},
 	"map_circum_Cstars": {
-		"nodustC": ["no dust", ""],
-		"gra": ["Graphites", "Bressan et al. (1998)"],
-		"AMC": ["100% AMC", "Groenewegen (2006)"],
-		"AMCSIC15": ["85% AMC + 15% SiC", "Groenewegen (2006)"]
+		"nodustC": ["nodustC", "no dust"],
+		"gra": ["gra", "Graphites as in Bressan et al. (1998)"],
+		"AMC": ["AMC", "100% AMC as in Groenewegen (2006)"],
+		"AMCSIC15": ["AMCSIC15", "85% AMC + 15% SiC as in Groenewegen (2006)"]
 	},
 	"map_isoc_val" : {
-		"0": ["Single isochrone", ""],
-		"1": ["Sequence of isochrones at constant Z", ""],
-		"2": ["Sequence of isochrones at constant t (variable Z)", "Groenewegen (2006)"]
+		"0": [0, "Single isochrone"],
+		"1": [1, "Sequence of isochrones at constant Z"],
+		"2": [2, "Sequence of isochrones at constant t (variable Z)"]
 	},
 	"__def_args__": {
-		"inTPC": 10,
-		"binary_frac": 0.3,
-		"binary_kind": 1,
-		"binary_mrinf": 0.7,
-		"binary_mrsup": 1,
-		"cmd_version": 2.3,
-		"dust_source": "nodust",
-		"dust_sourceC": "AMCSIC15",
-		"dust_sourceM": "dpmod60alox40",
+		"n_inTPC": 10,
+		"cmd_version": 2.9,
+		"dust_sourceC": "nodustC",
+		"dust_sourceM": "nodustM",
 		"eta_reimers": 0.2,
 		"extinction_av": 0,
-		"icm_lim": 4,
 		"imf_file": "tab_imf/imf_chabrier_lognormal.dat",
 		"isoc_age": 1e7,
 		"isoc_age0": 12.7e9,
@@ -140,12 +137,10 @@
 		"kind_mag": 2,
 		"kind_postagb": -1,
 		"kind_pulsecycle": 0,
-		"kind_tpagb": 3,
+		"kind_tpagb": 0,
 		"lf_deltamag": 0.2,
 		"lf_maginf": 20,
 		"lf_magsup": -20,
-		"mag_lim": 26,
-		"mag_res": 0.1,
 		"output_evstage": 0,
 		"output_gzip": 0,
 		"output_kind": 0,

--- a/ezpadova/parsec.py
+++ b/ezpadova/parsec.py
@@ -153,7 +153,7 @@ def file_type(filename, stream=False):
 # --------------------
 
 def __get_url_args(model=None, carbon=None, interp=None, Mstars=None,
-                   Cstars=None, dust=None, phot=None, **kwargs):
+                   Cstars=None, phot=None, **kwargs):
     """ Update options in the URL query using internal shortcuts
 
     Parameters
@@ -167,9 +167,6 @@ def __get_url_args(model=None, carbon=None, interp=None, Mstars=None,
 
     interp: str
         interpolation scheme
-
-    dust: str
-        circumstellar dust prescription :func:`help_circumdust`
 
     Mstars: str
         dust on M stars :func:`help_circumdust`
@@ -200,9 +197,6 @@ def __get_url_args(model=None, carbon=None, interp=None, Mstars=None,
 
     if interp is not None:
         d['kind_interp'] = map_interp[interp]
-
-    if dust is not None:
-        d['dust_source'] = map_circum_Mstars[dust]
 
     if Cstars is not None:
         d['dust_sourceC'] = map_circum_Cstars[Cstars]
@@ -333,9 +327,6 @@ def get_one_isochrone(age, metal, ret_table=True, **kwargs):
     interp: str
         interpolation scheme
 
-    dust: str
-        circumstellar dust prescription :func:`help_circumdust`
-
     Mstars: str
         dust on M stars :func:`help_circumdust`
 
@@ -391,9 +382,6 @@ def get_Z_isochrones(z0, z1, dz, age, ret_table=True, **kwargs):
 
     interp: str
         interpolation scheme
-
-    dust: str
-        circumstellar dust prescription :func:`help_circumdust`
 
     Mstars: str
         dust on M stars :func:`help_circumdust`
@@ -452,9 +440,6 @@ def get_t_isochrones(logt0, logt1, dlogt, metal, ret_table=True, **kwargs):
 
     interp: str
         interpolation scheme
-
-    dust: str
-        circumstellar dust prescription :func:`help_circumdust`
 
     Mstars: str
         dust on M stars :func:`help_circumdust`


### PR DESCRIPTION
I discovered that the default settings had C-star and M-star circumstellar dust enabled, although the CMD webform disables both.  Also, I found that the thermal pulse resolution parameter (n_inTPC) was not correctly defined (was "inTPC") and therefore defaulted to 0 instead of the webform's default of 10.

I edited the JSON file to update to the webform's default values (reasonable choices to me) and eliminated extra form parameters that are no longer present.  Additionally, I edited the code to better display help on circumstellar choices, added new choices, and eliminated a generic dust parameter that is no longer in use.