### PR TITLE
fix pip install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Installation
 Install with pip
 
 ```
-pip install git+git://github.com/mfouesneau/ezpadova
+pip install git+https://github.com/mfouesneau/ezpadova
 ```
 (`--user` if you want to install it in your user profile)
 


### PR DESCRIPTION
Installing with `pip install git+git` does not work. It should be `pip install git+https`. 
This PR fixes this in the README.md